### PR TITLE
[Feat/#37]: 알바생-좌측 메뉴 컴포넌트 제작 및 알바생 페이지 상단바 제작

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,6 +24,11 @@ import CompanyContractEditCheck from "pages/company/inCompany/CompanyContractEdi
 import CompanyAlba from "pages/company/inCompany/CompanyAlba";
 import CompanyQR from "pages/company/inCompany/CompanyQR";
 
+import AlbaMainTest from "pages/main/AlbaMainTest";
+import AlbaTest1 from "pages/main/AlbaTest1";
+import AlbaTest2 from "pages/main/AlbaTest2";
+import AlbaTest3 from "pages/main/AlbaTest3";
+
 function App() {
   return (
     <Provider store={store}>
@@ -68,8 +73,10 @@ function App() {
 
             <Route path="/company_main/:id/qr" element={<CompanyQR />}></Route>
 
-            <Route path="/ceomain" element={<CeoMain />} />
-            <Route path="/ceomain2" element={<CeoMain2 />} />
+            <Route path="/albamaintest" element={<AlbaMainTest />} />
+            <Route path="/albatest1" element={<AlbaTest1 />} />
+            <Route path="/albatest2" element={<AlbaTest2 />} />
+            <Route path="/albatest3" element={<AlbaTest3 />} />
           </Routes>
         </div>
       </BrowserRouter>

--- a/src/components/HeaderAlba.js
+++ b/src/components/HeaderAlba.js
@@ -1,0 +1,16 @@
+import "../App.scss";
+import React, { useEffect, useState } from "react";
+import { NavLink, useLocation } from "react-router-dom";
+
+const HeaderAlba = () => {
+  return (
+    <div className="topbar">
+      {/* <NavLink to="/company_list"> */}
+      <div className="topTitle">Wazard</div>
+      {/* </NavLink> */}
+      <div className="topMyPage">ㅁㅁㅁㅁㅁ</div>
+    </div>
+  );
+};
+
+export default HeaderAlba;

--- a/src/components/LeftMenuAlba.js
+++ b/src/components/LeftMenuAlba.js
@@ -1,0 +1,145 @@
+import React, { useEffect, useState } from "react";
+import { NavLink, useLocation } from "react-router-dom";
+import styled from "styled-components";
+
+const MenuLine = styled.div`
+  background-color: #fefefe;
+  border: 2px solid #4a53ff1a;
+  width: 280px;
+  height: 100vh;
+`;
+
+const MenuWrap = styled.div`
+  width: 280px;
+  height: 60px;
+`;
+
+const MenuTitle = styled.div`
+  color: #4a52ff;
+  text-align: center;
+  font-size: 30px;
+  font-weight: 900;
+  padding-top: 30px;
+  padding-bottom: 10px;
+  padding-right: 40px;
+`;
+
+const MenuItem = styled.div`
+  list-style: none;
+  width: 260px\;
+  height: 50px;
+  font-size: 24px;
+  color: #788cf2;
+  padding-top: 10px;
+  padding-left: 20px;
+
+  ${({ isActive }) =>
+    isActive &&
+    `
+    background-color: #f2f5fe;
+    border-left-style: solid;
+    border-color: #4a52ff;
+    border-width: 6px;
+    padding-left: 14px;
+  `}
+`;
+
+const SubMenu = styled.div`
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+  width: 260px;
+  height: 120px;
+  font-size: 22px;
+  color: #788cf2;
+
+  ${({ isActive }) =>
+    isActive &&
+    `
+    background-color: #f2f5fe;
+    border-left-style: solid;
+    border-color: #4a52ff;
+    border-width: 6px;
+    padding-left: 14px;
+    
+  `}
+`;
+
+const SubMenuItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+  width: 270px;
+  height: 30px;
+  font-size: 22px;
+  color: #788cf2;
+  padding-left: 10px;
+
+  ${({ isActive }) =>
+    isActive &&
+    `
+    background-color: #f2f5fe;
+    
+  `}
+`;
+
+const LeftMenuAlba = (props) => {
+  const location = useLocation();
+  const [showSubMenu, setShowSubMenu] = useState(false);
+  const { companyId } = props;
+  const handleSubMenuToggle = () => {
+    setShowSubMenu(!showSubMenu);
+  };
+
+  useEffect(() => {
+    // 로컬 스토리지에서 하위 메뉴의 열림/닫힘 상태를 가져와 설정합니다.
+    const storedIsOpen = localStorage.getItem("showSubMenu");
+    if (storedIsOpen) {
+      setShowSubMenu(JSON.parse(storedIsOpen));
+    }
+  }, []);
+
+  useEffect(() => {
+    // 하위 메뉴의 열림/닫힘 상태가 변경될 때마다 로컬 스토리지에 저장합니다.
+    localStorage.setItem("showSubMenu", JSON.stringify(showSubMenu));
+  }, [showSubMenu]);
+
+  return (
+    <MenuLine>
+      <MenuWrap>
+        <NavLink to={`/albamaintest`}>
+          <MenuTitle>알바생 페이지</MenuTitle>
+        </NavLink>
+
+        <NavLink
+          to={`/albatest1`}
+          className={location.pathname === `/albatest1` ? "active" : ""}
+        >
+          <MenuItem isActive={location.pathname === `/albatest1`}>
+            계약 정보 조회
+          </MenuItem>
+        </NavLink>
+
+        <NavLink
+          to={`/albatest2`}
+          className={location.pathname === `/albatest2` ? "active" : ""}
+        >
+          <MenuItem isActive={location.pathname === `/albatest2`}>
+            월급 통계 조회
+          </MenuItem>
+        </NavLink>
+
+        <NavLink
+          to={`/albatest3`}
+          className={location.pathname === `/albatest3` ? "active" : ""}
+        >
+          <MenuItem isActive={location.pathname === `/albatest3`}>
+            대타 기록
+          </MenuItem>
+        </NavLink>
+      </MenuWrap>
+    </MenuLine>
+  );
+};
+
+export default LeftMenuAlba;

--- a/src/pages/main/AlbaMainTest.js
+++ b/src/pages/main/AlbaMainTest.js
@@ -1,0 +1,14 @@
+import LeftMenuAlba from "components/LeftMenuAlba";
+import HeaderAlba from "../../components/HeaderAlba";
+
+const AlbaMainTest = () => {
+  return (
+    <div>
+      <HeaderAlba />
+      <LeftMenuAlba />
+      <div className="albaTestBody"></div>
+    </div>
+  );
+};
+
+export default AlbaMainTest;

--- a/src/pages/main/AlbaTest1.js
+++ b/src/pages/main/AlbaTest1.js
@@ -1,0 +1,14 @@
+import LeftMenuAlba from "components/LeftMenuAlba";
+import HeaderAlba from "../../components/HeaderAlba";
+
+const AlbaTest1 = () => {
+  return (
+    <div>
+      <HeaderAlba />
+      <LeftMenuAlba />
+      <div className="albaTestBody"></div>
+    </div>
+  );
+};
+
+export default AlbaTest1;

--- a/src/pages/main/AlbaTest2.js
+++ b/src/pages/main/AlbaTest2.js
@@ -1,0 +1,14 @@
+import LeftMenuAlba from "components/LeftMenuAlba";
+import HeaderAlba from "../../components/HeaderAlba";
+
+const AlbaTest2 = () => {
+  return (
+    <div>
+      <HeaderAlba />
+      <LeftMenuAlba />
+      <div className="albaTestBody"></div>
+    </div>
+  );
+};
+
+export default AlbaTest2;

--- a/src/pages/main/AlbaTest3.js
+++ b/src/pages/main/AlbaTest3.js
@@ -1,0 +1,14 @@
+import LeftMenuAlba from "components/LeftMenuAlba";
+import HeaderAlba from "../../components/HeaderAlba";
+
+const AlbaTest3 = () => {
+  return (
+    <div>
+      <HeaderAlba />
+      <LeftMenuAlba />
+      <div className="albaTestBody"></div>
+    </div>
+  );
+};
+
+export default AlbaTest3;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!--
[점검사항]
1. 제목 양식
2. Development 이슈 링크 걸기
3. Labels 태그 설정하기
4. 방금 작성한 코드가 최선일까 고민해보기
-->
### Issue Link
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
- #37 

### 핵심 내용
<!-- 무엇을 했는가 -->
- 알바생 페이지에 사용될 좌측 메뉴 컴포넌트 제작
- 알바생 페이지에 사용될 상단바 제작

### 핵심 구현 방법
<!-- 어떻게 했는가 -->
- 고용주 페이지에 사용된 메뉴 컴포넌트와 상단바 컴포넌트를 바탕으로 알바생 페이지에서 사용될 수 있도록 제작

### 전달 사항
<!-- Code Review시 얘기를 나누고 싶은 내용 -->
- 상단바도 wazard로고 클릭시 업체 리스트가 나올수 있도록 기존 고용주 페이지에서 사용하는 컴포넌트와 별개로 제작
- figma에 나와있는 메뉴 탭 중에서 달력 화면은 고용주 페이지와 마찬가지로 알바생 페이지를 클릭했을때 나오도록 하고 메뉴 탭에선 삭제함
- 알바생 메뉴 컴포넌트를 테스트하기 위해 AlbaMainTest, AlbaTest1, AlbaTest2, AlbaTest3 페이지 제작(추후 페이지 구현 시 삭제할 것임)