### PR TITLE
[Feat/#56] 마이페이지 좌측 메뉴 컴포넌트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-calendar": "^4.2.1",
         "react-daum-postcode": "^3.1.1",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.8.0",
         "react-redux": "^8.0.5",
         "react-router-dom": "^6.9.0",
         "react-scripts": "5.0.1",
@@ -15765,6 +15766,14 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-icons": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
+      "integrity": "sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-calendar": "^4.2.1",
     "react-daum-postcode": "^3.1.1",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.8.0",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.9.0",
     "react-scripts": "5.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -33,7 +33,7 @@ import AlbaInvitePage from "pages/alba/AlbaInvitedPage";
 import ScrollToTop from "components/ScrollToTop";
 
 import AlbaContract from "pages/alba/AlbaContract";
-
+import MyPageAlbaRecord from "pages/alba/MyPageAlbaRecord";
 
 function App() {
   return (
@@ -89,6 +89,7 @@ function App() {
             <Route path="/alba_list" element={<AlbaList />} />
             <Route path="/alba_invited" element={<AlbaInvitePage />} />
             <Route path="/alba_contract" element={<AlbaContract />} />
+            <Route path="/alba_record" element={<MyPageAlbaRecord />} />
           </Routes>
         </div>
       </BrowserRouter>

--- a/src/components/LeftMenuMyPage.js
+++ b/src/components/LeftMenuMyPage.js
@@ -83,7 +83,7 @@ const SubMenuItem = styled.div`
   `}
 `;
 
-const LeftMenuAlba = (props) => {
+const LeftMenuMyPage = (props) => {
   const location = useLocation();
   const [showSubMenu, setShowSubMenu] = useState(false);
   const { companyId } = props;
@@ -107,43 +107,25 @@ const LeftMenuAlba = (props) => {
   return (
     <MenuLine>
       <MenuWrap>
-        <NavLink to={`/albamaintest`}>
-          <MenuTitle>알바생 페이지</MenuTitle>
-        </NavLink>
+        {/* <NavLink to={`/albamaintest`}> */}
+        <MenuTitle>마이페이지</MenuTitle>
+        {/* </NavLink> */}
 
         <NavLink
           to={`/albatest1`}
           className={location.pathname === `/albatest1` ? "active" : ""}
         >
           <MenuItem isActive={location.pathname === `/albatest1`}>
-            계약 정보 조회
+            내정보 관리
           </MenuItem>
         </NavLink>
 
         <NavLink
-          to={`/albatest2`}
-          className={location.pathname === `/albatest2` ? "active" : ""}
+          to={`/alba_record`}
+          className={location.pathname === `/alba_record` ? "active" : ""}
         >
-          <MenuItem isActive={location.pathname === `/albatest2`}>
-            월급 통계 조회
-          </MenuItem>
-        </NavLink>
-
-        <NavLink
-          to={`/albatest3`}
-          className={location.pathname === `/albatest3` ? "active" : ""}
-        >
-          <MenuItem isActive={location.pathname === `/albatest3`}>
-            대타 기록
-          </MenuItem>
-        </NavLink>
-
-        <NavLink
-          to={`/albatest3`}
-          className={location.pathname === `/albatest3` ? "active" : ""}
-        >
-          <MenuItem isActive={location.pathname === `/albatest3`}>
-            출퇴근 조회
+          <MenuItem isActive={location.pathname === `/alba_record`}>
+            태도 점수 조회
           </MenuItem>
         </NavLink>
       </MenuWrap>
@@ -151,4 +133,4 @@ const LeftMenuAlba = (props) => {
   );
 };
 
-export default LeftMenuAlba;
+export default LeftMenuMyPage;

--- a/src/pages/alba/MyPageAlbaRecord.js
+++ b/src/pages/alba/MyPageAlbaRecord.js
@@ -1,0 +1,26 @@
+import { useSelector } from "react-redux";
+import { useNavigate, useParams } from "react-router-dom";
+import { useState } from "react";
+
+import HeaderAlba from "components/HeaderAlba";
+import LeftMenuMyPage from "components/LeftMenuMyPage";
+
+import "../../style/alba/albaRecord.scss";
+
+const MyPageAlbaRecord = () => {
+  return (
+    <div>
+      <HeaderAlba />
+      <div className="albaRecord-Wrapper">
+        <LeftMenuMyPage />
+        <div className="companyBody-Wrapper">
+          <div className="title">
+            <h2>종합 태도 점수</h2>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MyPageAlbaRecord;

--- a/src/style/alba/albaRecord.scss
+++ b/src/style/alba/albaRecord.scss
@@ -1,0 +1,17 @@
+.albaRecord-Wrapper {
+  display: flex;
+  .companyBody-Wrapper {
+    width: 80vw;
+    .title {
+      display: flex;
+      height: 60px;
+
+      align-items: center;
+      border-bottom: 4px solid #9db5fd;
+      margin-left: 20px;
+      h2 {
+        color: #000000;
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!--
[점검사항]
1. 제목 양식
2. Development 이슈 링크 걸기
3. Labels 태그 설정하기
4. 방금 작성한 코드가 최선일까 고민해보기
-->
### Issue Link
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
- #56 

### 핵심 내용
<!-- 무엇을 했는가 -->
- 마이페이지에서 사용될 좌측 메뉴 컴포넌트 구현

### 핵심 구현 방법
<!-- 어떻게 했는가 -->
- 고용주, 알바생 페이지에서 사용되는 좌측 메뉴 컴포넌트를 기반으로 마이페이지에서 사용되는 메뉴 컴포넌트 제작

### 전달 사항
<!-- Code Review시 얘기를 나누고 싶은 내용 -->
- 태도 점수 조회 버튼은 페이지 틀을 만들어 버튼 적용했음
- 내정보 관리는 페이지 이동 주소 추후 입력해야함
- AlbaRecord는 과거 알바기록 조회 페이지에 사용되는 js지만 커밋 실수로 같이 머지함(추후, 과거 알바기록 조회 구현시 수정 예정)
- 출퇴근 조회 버튼 추가했음(페이지 이동 주소만 추후에 넣으면 될듯)
