### PR TITLE
[Feat/#60] 고용주화면 - 특정 알바생 조회 화면에 결석 기록 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.4.0",
         "moment": "^2.29.4",
         "node-sass": "^7.0.3",
         "qrcode.react": "^3.1.0",
@@ -5401,6 +5402,29 @@
       "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -15413,6 +15437,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.4.0",
     "moment": "^2.29.4",
     "node-sass": "^7.0.3",
     "qrcode.react": "^3.1.0",

--- a/public/index.html
+++ b/public/index.html
@@ -16,35 +16,14 @@
       href="https://fonts.googleapis.com/css2?family=Goldman:wght@400;700&family=Nanum+Pen+Script&family=Yeon+Sung&display=swap"
       rel="stylesheet"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
+    <!-- <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" /> -->
+
     <title>React App</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -34,6 +34,7 @@ import ScrollToTop from "components/ScrollToTop";
 import AlbaContract from "pages/alba/AlbaContract";
 import MyPageAlbaRecord from "pages/alba/MyPageAlbaRecord";
 import AlbaMainPage from "pages/alba/inAlba/AlbaMainPage";
+import AlbaAttendance from "pages/alba/inAlba/AlbaAttendance";
 
 function App() {
   return (
@@ -86,6 +87,11 @@ function App() {
             <Route path="/albatest3" element={<AlbaTest3 />} />
 
             <Route path="/alba_main/:id" element={<AlbaMainPage />} />
+
+            <Route
+              path="/alba_main/:id/attendance"
+              element={<AlbaAttendance />}
+            ></Route>
 
             {/* 알바생화면 */}
             <Route path="/alba_list" element={<AlbaList />} />

--- a/src/pages/alba/inAlba/AlbaAttendance.js
+++ b/src/pages/alba/inAlba/AlbaAttendance.js
@@ -2,10 +2,12 @@ import HeaderAlba from "components/HeaderAlba";
 import LeftMenuAlba from "components/LeftMenuAlba";
 import { useState } from "react";
 import moment from "moment";
+import axios from "axios";
 
 function AlbaAttendance() {
   const [currentMonth, setCurrentMonth] = useState(moment());
   const [employeesAttend, setEmployeesAttend] = useState([
+    //출근 기록
     {
       id: 0,
       date: "2023-05-02",
@@ -28,7 +30,7 @@ function AlbaAttendance() {
       late: false,
     },
     {
-      id: 2,
+      id: 3,
       date: "2023-06-01",
       start_time: "08:50",
       end_time: "16:02",
@@ -38,12 +40,34 @@ function AlbaAttendance() {
   ]);
 
   const [employeesAbsent, setEmployeesAbsent] = useState([
+    //퇴근 기록
     {
       id: 0,
       date: "2023-05-24",
       absent: true,
     },
   ]);
+
+  //서버 api test
+  // axios.get("http://localhost:8080/company/own/0").then(function (response) {
+  //   console.log(response);
+  // });
+
+  // async function getData() {
+  //   try {
+  //     //응답 성공
+  //     const response = await axios.get("http://localhost:8080/company/own/0", {
+  //       params: {
+  //         //url 뒤에 붙는 param id값
+  //         accountId: 0,
+  //       },
+  //     });
+  //     console.log(response);
+  //   } catch (error) {
+  //     //응답 실패
+  //     console.error(error);
+  //   }
+  // }
 
   function handlePrevMonth() {
     setCurrentMonth(currentMonth.clone().subtract(1, "month"));
@@ -116,8 +140,6 @@ function AlbaAttendance() {
                 <tr>
                   <th>날짜</th>
                   <th>요일</th>
-
-                  <th>결석여부</th>
                 </tr>
               </thead>
               <tbody>
@@ -129,8 +151,6 @@ function AlbaAttendance() {
                         weekday: "long",
                       })}
                     </td>
-
-                    <td>{employee.absent ? "O" : "X"}</td>
                   </tr>
                 ))}
               </tbody>

--- a/src/pages/alba/inAlba/AlbaAttendance.js
+++ b/src/pages/alba/inAlba/AlbaAttendance.js
@@ -1,0 +1,145 @@
+import HeaderAlba from "components/HeaderAlba";
+import LeftMenuAlba from "components/LeftMenuAlba";
+import { useState } from "react";
+import moment from "moment";
+
+function AlbaAttendance() {
+  const [currentMonth, setCurrentMonth] = useState(moment());
+  const [employeesAttend, setEmployeesAttend] = useState([
+    {
+      id: 0,
+      date: "2023-05-02",
+      start_time: "08:59",
+      end_time: "16:01",
+      late: false,
+    },
+    {
+      id: 1,
+      date: "2023-05-03",
+      start_time: "08:59",
+      end_time: "16:01",
+      late: false,
+    },
+    {
+      id: 2,
+      date: "2023-05-23",
+      start_time: "08:53",
+      end_time: "16:01",
+      late: false,
+    },
+    {
+      id: 2,
+      date: "2023-06-01",
+      start_time: "08:50",
+      end_time: "16:02",
+      late: false,
+    },
+    // 알바생의 근무정보 추가
+  ]);
+
+  const [employeesAbsent, setEmployeesAbsent] = useState([
+    {
+      id: 0,
+      date: "2023-05-24",
+      absent: true,
+    },
+  ]);
+
+  function handlePrevMonth() {
+    setCurrentMonth(currentMonth.clone().subtract(1, "month"));
+  }
+  function handleNextMonth() {
+    setCurrentMonth(currentMonth.clone().add(1, "month"));
+  }
+
+  const filteredEmployeesAttend = employeesAttend.filter(
+    (employee) => moment(employee.date).month() === currentMonth.month()
+  );
+
+  const filteredEmployeesAbsent = employeesAbsent.filter(
+    (employee) => moment(employee.date).month() === currentMonth.month()
+  );
+  return (
+    <div className="alba-wrapper">
+      <HeaderAlba />
+      <div className="alba-navbar-wrapper">
+        <LeftMenuAlba />
+        <div className="alba-list-Wrapper">
+          <div className="title">
+            <h2>김민규</h2> {/* 본인이름 */}
+          </div>
+          <div className="month">
+            <button onClick={handlePrevMonth}>{"<"}</button>
+            <span>
+              {currentMonth.format("YYYY")}년 {currentMonth.format("M")}월{" "}
+            </span>
+            <button onClick={handleNextMonth}>{">"}</button>
+          </div>
+          <div className="member">
+            <div>
+              <h3>출근 기록부</h3>
+            </div>
+            <table className="alba-work-table">
+              <thead>
+                <tr>
+                  <th>날짜</th>
+                  <th>요일</th>
+                  <th>출근시간</th>
+                  <th>퇴근시간</th>
+                  <th>지각여부</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredEmployeesAttend.map((employee) => (
+                  <tr key={employee.id}>
+                    <td>{employee.date}</td>
+                    <td>
+                      {new Date(employee.date).toLocaleDateString("ko-KR", {
+                        weekday: "long",
+                      })}
+                    </td>
+                    <td>{employee.start_time}</td>
+                    <td>{employee.end_time}</td>
+                    <td>{employee.late ? "O" : "X"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="member-absent">
+            <div>
+              <h3>결근 기록부</h3>
+            </div>
+            <table className="alba-work-table">
+              <thead>
+                <tr>
+                  <th>날짜</th>
+                  <th>요일</th>
+
+                  <th>결석여부</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredEmployeesAbsent.map((employee) => (
+                  <tr key={employee.id}>
+                    <td>{employee.date}</td>
+                    <td>
+                      {new Date(employee.date).toLocaleDateString("ko-KR", {
+                        weekday: "long",
+                      })}
+                    </td>
+
+                    <td>{employee.absent ? "O" : "X"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AlbaAttendance;

--- a/src/pages/company/inCompany/CompanyAlba.js
+++ b/src/pages/company/inCompany/CompanyAlba.js
@@ -18,7 +18,8 @@ const CompanyAlba = () => {
     state.albalist.find((alba) => alba.alba_id === parseInt(id))
   );
   // console.log(alba);
-  const [employees, setEmployees] = useState([
+  //출근 기록
+  const [employeesAttend, setEmployeesAttend] = useState([
     {
       id: 0,
       company_id: 1,
@@ -41,6 +42,14 @@ const CompanyAlba = () => {
     },
     // 알바생의 근무정보 추가
   ]);
+  // 퇴근 기록
+  const [employeesAbsent, setEmployeesAbsent] = useState([
+    {
+      id: 0,
+      date: "2023-05-24",
+      absent: true,
+    },
+  ]);
 
   function handlePrevMonth() {
     setCurrentMonth(currentMonth.clone().subtract(1, "month"));
@@ -50,7 +59,11 @@ const CompanyAlba = () => {
     setCurrentMonth(currentMonth.clone().add(1, "month"));
   }
 
-  const filteredEmployees = employees.filter(
+  const filteredEmployeesAttend = employeesAttend.filter(
+    (employee) => moment(employee.date).month() === currentMonth.month()
+  );
+
+  const filteredEmployeesAbsent = employeesAbsent.filter(
     (employee) => moment(employee.date).month() === currentMonth.month()
   );
 
@@ -67,24 +80,24 @@ const CompanyAlba = () => {
 
   //지각 수정
   function handleLateToggleClick(employee) {
-    const updatedEmployees = employees.map((emp) => {
+    const updatedEmployees = employeesAttend.map((emp) => {
       if (emp.id === employee.id) {
         return { ...emp, late: !emp.late };
       }
       return emp;
     });
-    setEmployees(updatedEmployees);
+    setEmployeesAttend(updatedEmployees);
   }
 
   //결석 수정
   function handleAbsentToggleClick(employee) {
-    const updatedEmployees = employees.map((emp) => {
+    const updatedEmployees = employeesAbsent.map((emp) => {
       if (emp.id === employee.id) {
         return { ...emp, absent: !emp.absent };
       }
       return emp;
     });
-    setEmployees(updatedEmployees);
+    setEmployeesAbsent(updatedEmployees);
   }
 
   return (
@@ -92,7 +105,7 @@ const CompanyAlba = () => {
       <Header />
       <div className="companyAlba-Wrapper">
         <LeftMenuCeo companyId={company_id} />
-        <div className="list-Wrapper">
+        <div className="alba-list-Wrapper">
           <div className="title">
             <h2>{alba.user_name}</h2>
           </div>
@@ -104,6 +117,9 @@ const CompanyAlba = () => {
             <button onClick={handleNextMonth}>{">"}</button>
           </div>
           <div className="member">
+            <div>
+              <h3>출근 기록부</h3>
+            </div>
             <table className="alba-work-table">
               <thead>
                 <tr>
@@ -112,13 +128,11 @@ const CompanyAlba = () => {
                   <th>출근시간</th>
                   <th>퇴근시간</th>
                   <th>지각여부</th>
-                  <th>결석여부</th>
                   <th>지각버튼</th>
-                  <th>결석버튼</th>
                 </tr>
               </thead>
               <tbody>
-                {filteredEmployees.map((employee) => (
+                {filteredEmployeesAttend.map((employee) => (
                   <tr key={employee.id}>
                     <td>{employee.date}</td>
                     <td>
@@ -129,7 +143,7 @@ const CompanyAlba = () => {
                     <td>{employee.start_time}</td>
                     <td>{employee.end_time}</td>
                     <td>{employee.late ? "O" : "X"}</td>
-                    <td>{employee.absent ? "O" : "X"}</td>
+
                     <td>
                       {employee.late ? (
                         <button
@@ -149,22 +163,30 @@ const CompanyAlba = () => {
                         </button>
                       )}
                     </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="member-absent">
+            <div>
+              <h3>결근 기록부</h3>
+            </div>
+            <table className="alba-work-table">
+              <thead>
+                <tr>
+                  <th>날짜</th>
+                  <th>요일</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredEmployeesAbsent.map((employee) => (
+                  <tr key={employee.id}>
+                    <td>{employee.date}</td>
                     <td>
-                      {employee.absent ? (
-                        <button
-                          className="absentBtnCancel"
-                          onClick={() => handleAbsentToggleClick(employee)}
-                        >
-                          결석취소
-                        </button>
-                      ) : (
-                        <button
-                          className="absentBtn"
-                          onClick={() => handleConfirm("absent", employee)}
-                        >
-                          결석
-                        </button>
-                      )}
+                      {new Date(employee.date).toLocaleDateString("ko-KR", {
+                        weekday: "long",
+                      })}
                     </td>
                   </tr>
                 ))}

--- a/src/style/alba/albaStyle.scss
+++ b/src/style/alba/albaStyle.scss
@@ -132,12 +132,12 @@
 .alba-list-Wrapper {
   .member {
     width: 900px;
-    margin: 10px;
+    margin: 20px;
   }
   .member-absent {
     margin: 20px;
-    width: 900px;
-    margin: 10px;
+    width: 500px;
+    margin: 20px;
   }
   .title {
     margin-left: 20px;

--- a/src/style/alba/albaStyle.scss
+++ b/src/style/alba/albaStyle.scss
@@ -127,3 +127,20 @@
     }
   }
 }
+
+//알바생 출퇴근 조회
+.alba-list-Wrapper {
+  .member {
+    width: 900px;
+    margin: 10px;
+  }
+  .member-absent {
+    margin: 20px;
+  }
+  .title {
+    margin-left: 20px;
+    h2 {
+      color: #656577;
+    }
+  }
+}

--- a/src/style/alba/albaStyle.scss
+++ b/src/style/alba/albaStyle.scss
@@ -136,6 +136,8 @@
   }
   .member-absent {
     margin: 20px;
+    width: 900px;
+    margin: 10px;
   }
   .title {
     margin-left: 20px;

--- a/src/style/company/companyAlba.scss
+++ b/src/style/company/companyAlba.scss
@@ -256,25 +256,28 @@
   }
 }
 
-.companyAlba {
-  .month {
-    margin: 10px;
-    span {
-      font-size: 20px;
-      font-weight: 600;
-      text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.08);
-    }
-    button {
-      margin: 0px 10px 0px 10px;
-      width: 40px;
-      height: 40px;
-      border: none;
-      border-radius: 100px;
-      background-color: rgba(134, 157, 238, 0.5);
-      font-size: 16px;
+.month {
+  margin: 10px;
+  span {
+    font-size: 20px;
+    font-weight: 600;
+    text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.08);
+  }
+  button {
+    margin: 0px 10px 0px 10px;
+    width: 40px;
+    height: 40px;
+    border: none;
+    border-radius: 100px;
+    background-color: rgba(134, 157, 238, 0.5);
+    font-size: 16px;
+    cursor: pointer;
+    &:hover {
+      background-color: rgba(53, 65, 109, 0.5);
+      transition: 0.3s;
     }
   }
-  .member {
-    margin: 20px;
-  }
+}
+.member {
+  margin: 20px;
 }

--- a/src/style/company/companyAlba.scss
+++ b/src/style/company/companyAlba.scss
@@ -210,7 +210,7 @@
 .alba-work-table {
   border-collapse: collapse;
   width: 95%;
-  margin: 0 auto;
+  margin: 20px;
 
   tr {
     border-bottom: 1px solid rgba(172, 172, 172, 0.897);
@@ -277,7 +277,4 @@
       transition: 0.3s;
     }
   }
-}
-.member {
-  margin: 20px;
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!--
[점검사항]
1. 제목 양식
2. Development 이슈 링크 걸기
3. Labels 태그 설정하기
4. 방금 작성한 코드가 최선일까 고민해보기
-->
### Issue Link
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
- #60 

### 핵심 내용
<!-- 무엇을 했는가 -->
- 고용주 화면에서 결석기록부 테이블 추가

### 핵심 구현 방법
<!-- 어떻게 했는가 -->
-

### 전달 사항
<!-- Code Review시 얘기를 나누고 싶은 내용 -->
- 기존의 날짜마다 존재하던 결석 버튼은 알바생 조회부분으로 빼야함
![image](https://github.com/TeamWazard/wazard-front/assets/96363792/9b741993-4a87-4537-805f-ee2572a45ebc)
